### PR TITLE
set activegate dnsEntryPoint property

### DIFF
--- a/microk8s/ansible/playbooks/dtactivegate_tasks.yaml
+++ b/microk8s/ansible/playbooks/dtactivegate_tasks.yaml
@@ -16,7 +16,20 @@
 - name: ActiveGate - Install synthetic-enabled ActiveGate
   shell:
     cmd: DYNATRACE_SYNTHETIC_AUTO_INSTALL=true /bin/sh "{{ activegate_download_location }}" --enable-synthetic
-    creates: /opt/dynatrace/synthetic/uninstall.sh  
+    creates: /opt/dynatrace/synthetic/uninstall.sh
+
+- name: ActiveGate - Update dnsEntryPoint on custom.properties
+  blockinfile:
+    path: /var/lib/dynatrace/gateway/config/custom.properties
+    insertafter: "proxy-off = true"
+    block: |
+      [connectivity]
+      dnsEntryPoint = http://{{ ansible_facts.fqdn }}:9999
+
+- name: ActiveGate - Restart ActiveGate service
+  service:
+    name: dynatracegateway
+    state: restarted
 
 - name: ActiveGate - Get all Synthetic nodes
   uri:
@@ -29,6 +42,9 @@
     status_code: 200, 201, 204
   register: nodesresponse
   when: acebox_mode == 'demo'
+  until: nodesresponse.json | json_query("nodes[?hostname=='{{ ansible_facts.fqdn }}'].entityId")
+  retries: 15
+  delay: 10
 
 - name: ActiveGate - Set synthetic node entityId
   set_fact:


### PR DESCRIPTION
`ansible_facts.fqdn` did not match with the auto detected activegate hostname for AWS ec2 instances which prevents ansible from setting the activegate node id. Setting `dnsEntryPoint` on custom.properties and then restarting the activegate addresses the issue on all platforms.