### PR TITLE
Fix versions for darwin_arm64 platform

### DIFF
--- a/terraform/azure/versions.tf
+++ b/terraform/azure/versions.tf
@@ -2,8 +2,7 @@ terraform {
   required_version = ">= 0.12.20"
 
   required_providers {
-    random  = "~> 2.2"
-    local   = "~> 1.4"
-    azurerm = ">= 2.61.0"
+    random = "~> 3.1.2"
+    local  = "~> 2.2.2"
   }
 }

--- a/terraform/gcloud/versions.tf
+++ b/terraform/gcloud/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     google = ">= 3.58.0"
-    random = "~> 2.2"
-    local  = "~> 1.4"
+    random = "~> 3.1.2"
+    local  = "~> 2.2.2"
   }
 }


### PR DESCRIPTION
Currently you get an error on MacBook with M1 chip since the provider versions don't have support for it.
This fixes that.

```
$ terraform init
Initializing modules...
- provisioner in ../modules/ace-box-provisioner

Initializing the backend...

Initializing provider plugins...
- Finding hashicorp/random versions matching "~> 2.2"...
- Finding latest version of hashicorp/tls...
- Finding latest version of hashicorp/null...
- Finding hashicorp/local versions matching "~> 1.4"...
- Finding hashicorp/google versions matching ">= 3.58.0"...
- Installing hashicorp/google v4.18.0...
- Installed hashicorp/google v4.18.0 (signed by HashiCorp)
- Installing hashicorp/tls v3.3.0...
- Installed hashicorp/tls v3.3.0 (signed by HashiCorp)
- Installing hashicorp/null v3.1.1...
- Installed hashicorp/null v3.1.1 (signed by HashiCorp)
╷
│ Error: Incompatible provider version
│ 
│ Provider registry.terraform.io/hashicorp/random v2.3.1 does not have a package available for your current platform, darwin_arm64.
│ 
│ Provider releases are separate from Terraform CLI releases, so not all providers are available for all platforms. Other versions of this provider may have different platforms supported.
╵

╷
│ Error: Incompatible provider version
│ 
│ Provider registry.terraform.io/hashicorp/local v1.4.0 does not have a package available for your current platform, darwin_arm64.
│ 
│ Provider releases are separate from Terraform CLI releases, so not all providers are available for all platforms. Other versions of this provider may have different platforms supported.
╵
```