### PR TITLE
319 bug incl synth variable is defined but not used in easytravel

### DIFF
--- a/user-skel/ansible/roles/app-easytravel/Readme.md
+++ b/user-skel/ansible/roles/app-easytravel/Readme.md
@@ -54,7 +54,8 @@ To enable monaco:
     name: monaco
 ```
 
-> Note: the below applies Dynatrace configurations with the monaco project embedded in the role
+> Note: the below applies Dynatrace configurations with the monaco project embedded in the role.
+>
 > To enable private synthetic monitor for EasyTeavel via Dynatrace ActiveGate, set the "skip_synthetic_monitor" variable as "false". The default value is "true"
 
 ```yaml

--- a/user-skel/ansible/roles/app-easytravel/Readme.md
+++ b/user-skel/ansible/roles/app-easytravel/Readme.md
@@ -55,11 +55,14 @@ To enable monaco:
 ```
 
 > Note: the below applies Dynatrace configurations with the monaco project embedded in the role
+> To enable private synthetic monitor for EasyTeavel via Dynatrace ActiveGate, set the "skip_synthetic_monitor" variable as "false". The default value is "true"
 
 ```yaml
 - include_role:
     name: app-easytravel
     tasks_from: apply-monaco
+  vars:
+    skip_synthetic_monitor: "false"
 ```
 
 To delete the configuration:
@@ -77,7 +80,7 @@ Dynatrace Configurations List:
       - "auto-tag/environment"
       - "conditional-naming-processgroup/ACE Box - containername.namespace"
       - "conditional-naming-service/app.environment"
-      - "synthetic-location/ACE-BOX"
+      - "synthetic-location/ACE-BOX"  # if skip_synthetic_monitor: "false"
     
     Easytravel Aplication Specific:
         - "app-detection-rule/app.easytravel.prod"
@@ -86,7 +89,7 @@ Dynatrace Configurations List:
         - "application-web/app.easytravel-angular.prod"
         - "auto-tag/easytravel-prod"
         - "management-zone/easytravel-prod"
-        - "synthetic-monitor/webcheck.easytravel.prod"
-        - "synthetic-monitor/webcheck.easytravel-angular.prod"
-        - "synthetic-monitor/browser.easytravel-angular.prod.home"
-        - "synthetic-monitor/browser.easytravel.prod.home"
+        - "synthetic-monitor/webcheck.easytravel.prod"  # if skip_synthetic_monitor: "false"
+        - "synthetic-monitor/webcheck.easytravel-angular.prod" # if skip_synthetic_monitor: "false"
+        - "synthetic-monitor/browser.easytravel-angular.prod.home" # if skip_synthetic_monitor: "false"
+        - "synthetic-monitor/browser.easytravel.prod.home" # if skip_synthetic_monitor: "false"

--- a/user-skel/ansible/roles/app-easytravel/files/monaco/projects/easytravel/synthetic-monitor/easytravel-browser-monitor.json
+++ b/user-skel/ansible/roles/app-easytravel/files/monaco/projects/easytravel/synthetic-monitor/easytravel-browser-monitor.json
@@ -1,7 +1,7 @@
 {
     "name": "{{.name}}",
     "frequencyMin": {{.frequencyInMin}},
-    "enabled": {{ .enabled }},
+    "enabled": true,
     "type": "BROWSER",
     "createdFrom": "GUI",
     "script": {

--- a/user-skel/ansible/roles/app-easytravel/files/monaco/projects/easytravel/synthetic-monitor/health-check-monitor.json
+++ b/user-skel/ansible/roles/app-easytravel/files/monaco/projects/easytravel/synthetic-monitor/health-check-monitor.json
@@ -1,7 +1,7 @@
 {
     "name": "{{ .name }}",
     "frequencyMin": {{ .frequencyInMin }},
-    "enabled": {{ .enabled }},
+    "enabled": true,
     "type": "HTTP",
     "script": {
       "version": "1.0",

--- a/user-skel/ansible/roles/app-easytravel/files/monaco/projects/easytravel/synthetic-monitor/health-check-monitor.json
+++ b/user-skel/ansible/roles/app-easytravel/files/monaco/projects/easytravel/synthetic-monitor/health-check-monitor.json
@@ -38,21 +38,20 @@
     ],
     "anomalyDetection": {
       "outageHandling": {
-        "globalOutage": false,
-        "localOutage": true,
+        "globalOutage": true,
+        "globalOutagePolicy": {
+          "consecutiveRuns": 1
+        },
+        "localOutage": false,
         "localOutagePolicy": {
-          "affectedLocations": 1,
-          "consecutiveRuns": 3
-        }
+          "affectedLocations": null,
+          "consecutiveRuns": null
+        },
+        "retryOnError": true
       },
       "loadingTimeThresholds": {
-        "enabled": false,
-        "thresholds": [
-          {
-            "type": "TOTAL",
-            "valueMs": 0
-          }
-        ]
+        "enabled": true,
+        "thresholds": []
       }
     },
     "tags": [

--- a/user-skel/ansible/roles/app-easytravel/files/monaco/projects/easytravel/synthetic-monitor/synthetic-monitors.yaml
+++ b/user-skel/ansible/roles/app-easytravel/files/monaco/projects/easytravel/synthetic-monitor/synthetic-monitors.yaml
@@ -13,7 +13,7 @@ health-easytravel-prod:
     - tag: "/easytravel/auto-tag/tagging-easytravel-prod.name"
     - applicationId: "/easytravel/application-web/app-easytravel-prod.id"
     - frequencyInMin: "1"
-    - enabled: "true"
+    - skipDeployment: "{{ .Env.SKIP_SYNTH }}"
 
 health-easytravel-angular-prod:
     - name: "webcheck.easytravel-angular.prod"
@@ -24,7 +24,7 @@ health-easytravel-angular-prod:
     - tag: "/easytravel/auto-tag/tagging-easytravel-prod.name"
     - applicationId: "/easytravel/application-web/app-easytravel-angular-prod.id"
     - frequencyInMin: "1"
-    - enabled: "true"
+    - skipDeployment: "{{ .Env.SKIP_SYNTH }}"
 
 browser-easytravel-prod-home:
     - name: "browser.easytravel.prod.home"
@@ -35,7 +35,7 @@ browser-easytravel-prod-home:
     - tag: "/easytravel/auto-tag/tagging-easytravel-prod.name"
     - applicationId: "/easytravel/application-web/app-easytravel-prod.id"
     - frequencyInMin: "5"
-    - enabled: "true"
+    - skipDeployment: "{{ .Env.SKIP_SYNTH }}"
 
 browser-easytravel-angular-prod-home:
     - name: "browser.easytravel-angular.prod.home"
@@ -46,4 +46,4 @@ browser-easytravel-angular-prod-home:
     - tag: "/easytravel/auto-tag/tagging-easytravel-prod.name"
     - applicationId: "/easytravel/application-web/app-easytravel-angular-prod.id"
     - frequencyInMin: "5"
-    - enabled: "true"
+    - skipDeployment: "{{ .Env.SKIP_SYNTH }}"

--- a/user-skel/ansible/roles/app-easytravel/files/monaco/projects/infrastructure/synthetic-location/synthetic-location.yaml
+++ b/user-skel/ansible/roles/app-easytravel/files/monaco/projects/infrastructure/synthetic-location/synthetic-location.yaml
@@ -4,3 +4,4 @@ config:
 acebox:
     - name: "ACE-BOX"
     - nodeId: "{{ .Env.SYNTH_NODE_ID }}"
+    - skipDeployment: "{{ .Env.SKIP_SYNTH }}"

--- a/user-skel/ansible/roles/app-easytravel/tasks/apply-monaco.yml
+++ b/user-skel/ansible/roles/app-easytravel/tasks/apply-monaco.yml
@@ -18,7 +18,7 @@
         INGRESS_DOMAIN: "{{ ingress_domain }}"
         APP_NAMESPACE: "{{ easytravel_namespace }}"
         SKIP_SYNTH: "{{ skip_synthetic_monitor }}"
-        SYNTH_NODE_ID: "{{ dt_synthetic_node_id }}"
+        SYNTH_NODE_ID: "{{ dt_synthetic_node_id | default(None) }}"
   vars:
     monaco_project: "easytravel"
     monaco_projects_root: "{{ monaco_projects_folder }}" 

--- a/user-skel/ansible/roles/app-easytravel/tasks/apply-monaco.yml
+++ b/user-skel/ansible/roles/app-easytravel/tasks/apply-monaco.yml
@@ -1,12 +1,13 @@
 ---
 - set_fact:
     monaco_projects_folder: "{{ role_path }}/files/monaco/projects"
+    skip_synthetic_monitor: "true"
 
 - name: Source Private Synthetic Node ID
   include_role:
     name: dt-activegate-private-synth-classic
     tasks_from: source-node-id
-  when: dt_synthetic_node_id is not defined 
+  when: skip_synthetic_monitor == "false" and dt_synthetic_node_id is not defined 
 
 - name: Easytravel - Apply Monitoring as Code
   include_role:
@@ -15,9 +16,9 @@
     apply:
       environment:
         INGRESS_DOMAIN: "{{ ingress_domain }}"
-        SYNTH_NODE_ID: "{{ dt_synthetic_node_id }}"
         APP_NAMESPACE: "{{ easytravel_namespace }}"
-        INCL_SYNTH: "false"
+        SKIP_SYNTH: "{{ skip_synthetic_monitor }}"
+        SYNTH_NODE_ID: "{{ dt_synthetic_node_id }}"
   vars:
     monaco_project: "easytravel"
     monaco_projects_root: "{{ monaco_projects_folder }}" 


### PR DESCRIPTION
I used skipDeployment parameter to decide whether or not to deploy the monaco configurations on EasyTravel. Instrad of INCL_SYNTH param, it is SKIP_SYNTH param to be used for skipDeployment