### PR TITLE
Bump hashicorp/aws version

### DIFF
--- a/terraform/aws/terraform.tf
+++ b/terraform/aws/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.27"
+      version = "> 3.27"
     }
 
     random = {


### PR DESCRIPTION
Otherwise this conflicts with other requirements for this provider and terraform init fails.