### PR TITLE
srg demo in target list

### DIFF
--- a/user-skel/.ace/ace
+++ b/user-skel/.ace/ace
@@ -48,7 +48,7 @@ enable_targets = [
     'demo_all',
     'demo_monaco_gitops',
     'demo_ar_workflows_gitlab',
-    'demo_release_validation_srg_gitlab'
+    'demo_release_validation_srg_gitlab',
     'demo_ar_workflows_ansible'
 ]
 

--- a/user-skel/ansible/main-v2.yml
+++ b/user-skel/ansible/main-v2.yml
@@ -46,6 +46,8 @@
     - role: demo-release-validation-srg-gitlab
       tags:
         - demo_release_validation_srg_gitlab
+        - never
+
     # Use case - Auto Remediation Workflows with Ansible
     - role: demo-ar-workflows-ansible
       tags:


### PR DESCRIPTION
While merging the release validation srg demo into dev, there was a conflict on demo target list, while resolving the conflict, the comma was missed between the demo values. It is now resolved