### PR TITLE
Feature/fix hipstershop

### DIFF
--- a/user-skel/ansible_collections/ace_box/ace_box/roles/app-hipstershop/templates/hipstershop-kustomization.yml.j2
+++ b/user-skel/ansible_collections/ace_box/ace_box/roles/app-hipstershop/templates/hipstershop-kustomization.yml.j2
@@ -18,13 +18,13 @@ resources:
 - resources/redis-pvc.yaml
 - resources/hipstershop-ingress.yaml # this file is created at run-time to set the dynamic ingress details
 
-patchesStrategicMerge:
-- patches/checkoutservice.yaml
-- patches/currencyservice.yaml
-- patches/paymentservice.yaml
-- patches/frontend-external.yaml
-- patches/redis.yaml
-- patches/loadgenerator.yaml
+patches:
+- path: patches/checkoutservice.yaml
+- path: patches/currencyservice.yaml
+- path: patches/paymentservice.yaml
+- path: patches/frontend-external.yaml
+- path: patches/redis.yaml
+- path: patches/loadgenerator.yaml
 
 images:
 - name: ghcr.io/mreider/adservice


### PR DESCRIPTION
Hipstershop role was broken. 
```
module.provisioner.null_resource.provisioner_ace_enable (remote-exec): TASK [app-hipstershop : Kustomize Build] ***************************************
module.provisioner.null_resource.provisioner_ace_enable (remote-exec): fatal: [localhost]: FAILED! => {"msg": "kustomize command failed with: # Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.\n"}
```

kustomize change of patches declaration. Check doc: https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/patches/