### PR TITLE
schemaVersion omitted for srg and ownership settings

### DIFF
--- a/user-skel/ansible_collections/ace_box/ace_box/roles/demo-release-validation-srg-gitlab/files/monaco/app/_config.yaml
+++ b/user-skel/ansible_collections/ace_box/ace_box/roles/demo-release-validation-srg-gitlab/files/monaco/app/_config.yaml
@@ -25,7 +25,6 @@ configs:
     type:
       settings:
         schema: builtin:ownership.teams
-        schemaVersion: 1.0.6
         scope: environment
     groupOverrides:
     - group: production

--- a/user-skel/ansible_collections/ace_box/ace_box/roles/demo-release-validation-srg-gitlab/files/monaco/srg/_config.yaml
+++ b/user-skel/ansible_collections/ace_box/ace_box/roles/demo-release-validation-srg-gitlab/files/monaco/srg/_config.yaml
@@ -4,7 +4,6 @@ configs:
     type:
       settings:
         schema: app:dynatrace.site.reliability.guardian:guardians
-        schemaVersion: "1.1.1"
         scope: environment
     config:
       name: "Simplenode Guardian for ACE Demo"


### PR DESCRIPTION
schemaVersion omitted for srg and ownership settings to fix the schema version related issues. 
"builtin:rum.web.app-detection" schemaVersion stayed same as we have not encountered any issue with schema mismatch so far