### PR TITLE
dt-operator role cluster naming feature

### DIFF
--- a/user-skel/ansible_collections/ace_box/ace_box/roles/dt-operator/Readme.md
+++ b/user-skel/ansible_collections/ace_box/ace_box/roles/dt-operator/Readme.md
@@ -36,6 +36,7 @@ dt_operator_release: "v0.9.1" # the latest supported dynatrace operator release
 dt_operator_namespace: "dynatrace"
 host_group: "ace-box"
 operator_mode: "classicFullStack"
+cluster_name: "your-cluster-name"
 ```
 
 Possible values for operator_mode:

--- a/user-skel/ansible_collections/ace_box/ace_box/roles/dt-operator/defaults/main.yml
+++ b/user-skel/ansible_collections/ace_box/ace_box/roles/dt-operator/defaults/main.yml
@@ -5,3 +5,4 @@ host_group: "ace-box"
 dt_operator_dt_access_token_name: "ace_box_dt_operator_api_token"
 dt_operator_dt_data_ingest_token_name: "ace_box_dt_operator_ingest_token"
 operator_mode: "classicFullStack"
+cluster_name: dynakube

--- a/user-skel/ansible_collections/ace_box/ace_box/roles/dt-operator/templates/applicationMonitoring.yaml.j2
+++ b/user-skel/ansible_collections/ace_box/ace_box/roles/dt-operator/templates/applicationMonitoring.yaml.j2
@@ -17,6 +17,7 @@ metadata:
   # Automatically connect the kubernetes api to the dynatrace tenant endpoint to enable kubernetes monitoring.
   annotations:
     feature.dynatrace.com/automatic-kubernetes-api-monitoring: "true"
+    feature.dynatrace.com/automatic-kubernetes-api-monitoring-cluster-name: "{{cluster_name}}"
 spec:
   # Dynatrace apiUrl including the `/api` path at the end.
   # For SaaS, set `ENVIRONMENTID` to your environment ID.

--- a/user-skel/ansible_collections/ace_box/ace_box/roles/dt-operator/templates/classicFullStack.yaml.j2
+++ b/user-skel/ansible_collections/ace_box/ace_box/roles/dt-operator/templates/classicFullStack.yaml.j2
@@ -16,6 +16,7 @@ metadata:
   namespace: dynatrace
   annotations:
     feature.dynatrace.com/automatic-kubernetes-api-monitoring: "true"
+    feature.dynatrace.com/automatic-kubernetes-api-monitoring-cluster-name: "{{cluster_name}}"
 spec:
   # Dynatrace apiUrl including the `/api` path at the end.
   # For SaaS, set `YOUR_ENVIRONMENT_ID` to your environment ID.

--- a/user-skel/ansible_collections/ace_box/ace_box/roles/dt-operator/templates/cloudNativeFullStack.yaml.j2
+++ b/user-skel/ansible_collections/ace_box/ace_box/roles/dt-operator/templates/cloudNativeFullStack.yaml.j2
@@ -17,6 +17,7 @@ metadata:
   # Automatically connect the kubernetes api to the dynatrace tenant endpoint to enable kubernetes monitoring.
   annotations:
     feature.dynatrace.com/automatic-kubernetes-api-monitoring: "true"
+    feature.dynatrace.com/automatic-kubernetes-api-monitoring-cluster-name: "{{cluster_name}}"
 spec:
   # Dynatrace apiUrl including the `/api` path at the end.
   # For SaaS, set `ENVIRONMENTID` to your environment ID.


### PR DESCRIPTION
Useful for hands-on trainings with participants in the same tenant, to easily identify their k8s clusters