### PR TITLE
Fix for "terraform init" failing (AWS Provider 5.4.0 ---> 5.47.0)

### DIFF
--- a/terraform/aws/terraform.tf
+++ b/terraform/aws/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.4.0"
+      version = "5.47.0"
     }
 
     random = {


### PR DESCRIPTION
"terraform init" fails when trying to create a new ACE Box (Terraform on AWS). That is due to hashicorp/aws version 5.4.0.

Error: "Could not retrieve the list of available versions for provider hashicorp/aws ..."

Update to latest version 5.47.0 fixes this issue ("terraform init" runs through fine without issue above)

![image](https://github.com/Dynatrace/ace-box/assets/14933193/41a5df81-fbc2-447c-82ad-a6efe480c008)
