### PR TITLE
Easytrade no deploy

### DIFF
--- a/user-skel/ansible_collections/ace_box/ace_box/roles/app-easytrade/Readme.md
+++ b/user-skel/ansible_collections/ace_box/ace_box/roles/app-easytrade/Readme.md
@@ -30,6 +30,8 @@ easytrade_namespace: "easytrade" # namespace that EasyTrade will be deployed in
 easytrade_domain: "easytrade.{{ ingress_domain }}" #ingress domain for regular EasyTrade
 easytrade_addDashboardLink: true # add a link to the dashboard when enabled
 easytrade_addDashboardPreview: true # add a preview to the dashboard when enabled
+easytrade_deploy: true # Choose to deploy or not easytrade. True by default but useful to set it to false when it is combined with gitlab or any other ci/cd, so it's gets deployed from the pipeline
+easytrade_owner: "ace-box" # Customize the dt.owner annotation for your lab.
 ```
 
 ### (Optional) To enable observability with Dynatrace OneAgent

--- a/user-skel/ansible_collections/ace_box/ace_box/roles/app-easytrade/defaults/main.yml
+++ b/user-skel/ansible_collections/ace_box/ace_box/roles/app-easytrade/defaults/main.yml
@@ -7,3 +7,5 @@ easytrade_addDashboardLink: true
 easytrade_addDashboardPreview: true
 easytrade_build_version: "1.0.0"
 easytrade_release_stage: "staging"
+easytrade_deploy: true
+easytrade_owner: "ace-box"

--- a/user-skel/ansible_collections/ace_box/ace_box/roles/app-easytrade/tasks/main.yaml
+++ b/user-skel/ansible_collections/ace_box/ace_box/roles/app-easytrade/tasks/main.yaml
@@ -42,8 +42,17 @@
     group: "{{ ace_box_user }}"
     mode: '0644'
 
+- name: Template Easytrade Labels Patch
+  template:
+    src: "{{ role_path }}/templates/easytrade-labels-patch.yml.j2"
+    dest: "{{ role_path }}/files/kustomize/base/easytrade-labels-patch.yml"
+    owner: "{{ ace_box_user }}"
+    group: "{{ ace_box_user }}"
+    mode: '0644'
+
 - name: Deploy Kubernetes manifests
   include_tasks: deploy_kubernetes_manifests.yml
+  when: easytrade_deploy 
 
 - name: Add dashboard links
   include_tasks: add-dashboard-links.yml

--- a/user-skel/ansible_collections/ace_box/ace_box/roles/app-easytrade/tasks/main.yaml
+++ b/user-skel/ansible_collections/ace_box/ace_box/roles/app-easytrade/tasks/main.yaml
@@ -44,8 +44,8 @@
 
 - name: Template Easytrade Labels Patch
   template:
-    src: "{{ role_path }}/templates/easytrade-labels-patch.yml.j2"
-    dest: "{{ role_path }}/files/kustomize/base/easytrade-labels-patch.yml"
+    src: "{{ role_path }}/templates/kubernetes-labels-patch.yml.j2"
+    dest: "{{ role_path }}/files/kustomize/base/kubernetes-labels-patch.yml"
     owner: "{{ ace_box_user }}"
     group: "{{ ace_box_user }}"
     mode: '0644'

--- a/user-skel/ansible_collections/ace_box/ace_box/roles/app-easytrade/templates/kubernetes-labels-patch.yml.j2
+++ b/user-skel/ansible_collections/ace_box/ace_box/roles/app-easytrade/templates/kubernetes-labels-patch.yml.j2
@@ -1,0 +1,36 @@
+- op: add
+  path: /spec/template/metadata/labels/app.kubernetes.io~1version
+  value: "1.0.0"
+
+- op: add
+  path: /spec/template/metadata/labels/app.kubernetes.io~1part-of
+  value: easytrade
+
+- op: add
+  path: /spec/template/metadata/labels/dt.owner
+  value: {{easytrade_owner}}
+
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value: 
+    name: DT_RELEASE_VERSION
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.labels['app.kubernetes.io/version']
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value: 
+    name: DT_RELEASE_PRODUCT
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.labels['app.kubernetes.io/part-of']
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value: 
+    name: DT_RELEASE_BUILD_VERSION
+    value: "1.0.1-0"
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value: 
+    name: DT_RELEASE_STAGE
+    value: "staging"


### PR DESCRIPTION
easytrade functionalities on variables:
- `easytrade_deploy`: true # Choose to deploy or not easytrade. True by default but useful to set it to false when it is combined with gitlab or any other ci/cd, so it's gets deployed from the pipeline
- `easytrade_owner`: "ace-box" # Customize the dt.owner annotation for your lab.