### PR TITLE
dt-operator appOnly approach + doc

### DIFF
--- a/user-skel/ansible_collections/ace_box/ace_box/roles/dt-operator/Readme.md
+++ b/user-skel/ansible_collections/ace_box/ace_box/roles/dt-operator/Readme.md
@@ -1,6 +1,29 @@
 # dt-operator
 
-This currated role can be used to deploy Dynatrace k8s operator (Dynakube) with a classic full-stack, cloud native full-stack or app-only injection deployment strategy. 
+This currated role deploys the Dynatrace Operator to monitor your Kubernetes cluster. Dynatrace provides different deployment options: `application-only + k8s-api`, `cloudNativeFullStack`, and `classicFullStack`. Notice that the prerequisites for each are different
+
+## Prerequisites
+
+### (RECOMMENDED) application-only + k8s-api or cloudNativeFullStack
+
+This role depends on the following roles to be deployed beforehand:
+
+```yaml
+- include_role:
+    name: k3s
+```
+
+> Note: if you deploy k3s, you don't need to deploy microk8s and viceversa
+
+### classicFullStack
+
+This role depends on the following roles to be deployed beforehand:
+```yaml
+- include_role:
+    name: microk8s
+```
+
+> Note: if you deploy microk8s, you don't need to deploy k3s and viceversa
 
 Dynatrace Operator manages classic full-stack injection after the following resources are deployed.
 
@@ -12,41 +35,56 @@ Dynatrace Operator manages classic full-stack injection after the following reso
 
 For the details, please check this link: https://www.dynatrace.com/support/help/shortlink/dto-deploy-options-k8s#classic
 
-## Using the role
 
-### Role Requirements
-This role depends on the following roles to be deployed beforehand:
-```yaml
-- include_role:
-    name: microk8s
-```
-
-### Deploying Dynatrace K8s Operator
+## Deploying Dynatrace K8s Operator
 
 ```yaml
 - include_role:
     name: dt-operator
 ```
-
-Variables that can be set are as follows:
+The Operator gets deployed in application only mode approach, check the `roles/dt-operator/defaults/main.yml`:
 
 ```yaml
----
-dt_operator_release: "v0.9.1" # the latest supported dynatrace operator release
-dt_operator_namespace: "dynatrace"
-host_group: "ace-box"
-operator_mode: "classicFullStack"
-cluster_name: "your-cluster-name"
+operator_mode: "applicationMonitoring"  # default & prefered deployment option
+dt_operator_release: "1.3.0-rc.0"       # operator release should be linked with the right operator mode
+log_monitoring: "fluentbit"
+edge_connect: false
 ```
 
-Possible values for operator_mode:
-- applicationMonitoring
-- classicFullStack
-- cloudNativeFullStack
+> Note: log monitoring is enabled by default, using the fluentbit collector and edge connect is disabled by default, but can be switched to 
+To deploy the Operator in application only mode (and default approach), variables can be set as follow:
 
-This role creates a namespace in the Kubernetes cluster and deploys the Dynatrace operator along with the Dynakube custom resource.
+```yaml
+- include_role:
+    name: dt-operator
+  vars:
+    edge_connect: true
+```
 
-### Other Tasks in the Role
+If you decide to use the classicFullStack approach, you need to specify the variables as follow:
+
+```yaml
+- include_role:
+    name: dt-operator
+  vars:
+    operator_mode: "classicFullStack"  
+    dt_operator_release: "1.2.2"
+```
+
+## Extra variables
+
+You can configure the cluster name and host group as follows:
+
+```yaml
+- include_role:
+    name: dt-operator
+  vars:
+    host_group: custom_host_group
+    cluster_name: custom_cluster_name
+```
+
+
+## Other Tasks in the Role
 
 "source-secrets" retrieves the Operator bearer token and stores it in the following variable:
 - `dt_operator_kube_bearer_token`

--- a/user-skel/ansible_collections/ace_box/ace_box/roles/dt-operator/defaults/main.yml
+++ b/user-skel/ansible_collections/ace_box/ace_box/roles/dt-operator/defaults/main.yml
@@ -13,10 +13,16 @@
 # limitations under the License.
 
 ---
-dt_operator_release: "v1.2.2"
+operator_mode: "applicationMonitoring"  # default & prefered deployment option
+dt_operator_release: "1.3.0-rc.0"       # operator release should be linked with the right operator mode
+log_monitoring: "fluentbit"
+edge_connect: false
+
+# operator_mode: "classicFullStack"  
+# dt_operator_release: "1.2.2"
+
 dt_operator_namespace: "dynatrace"
 host_group: "ace-box"
 dt_operator_dt_access_token_name: "ace_box_dt_operator_api_token"
 dt_operator_dt_data_ingest_token_name: "ace_box_dt_operator_ingest_token"
-operator_mode: "classicFullStack"
 cluster_name: dynakube

--- a/user-skel/ansible_collections/ace_box/ace_box/roles/dt-operator/tasks/main.yml
+++ b/user-skel/ansible_collections/ace_box/ace_box/roles/dt-operator/tasks/main.yml
@@ -50,6 +50,20 @@
     retries: 20
     delay: 5
     until: dt_operator is not failed
+  when: operator_mode != "applicationMonitoring"
+
+- name: Add stable chart repo
+  kubernetes.core.helm:
+    name: dynatrace-operator
+    chart_ref: "oci://public.ecr.aws/dynatrace/dynatrace-operator"
+    # set_values:
+    #   - value: imageRef.repository=gcr.io/dynatrace-marketplace-prod/dynatrace-operator
+    #     value_type: string
+    release_namespace: dynatrace
+    create_namespace: true
+    atomic: true
+    chart_version: "{{dt_operator_release}}"
+  when: operator_mode == "applicationMonitoring"
 
 - block:
   - name: Download CSI manifest
@@ -65,7 +79,7 @@
     retries: 20
     delay: 5
     until: dt_operator_csi is not failed
-    when: operator_mode != "classicFullStack"
+  when: operator_mode != "applicationMonitoring"
 
 - block:
   - name: Template Dynakube manifest
@@ -84,6 +98,7 @@
     delay: 20
     until: dynakube is not failed
 
+- block:
   - name: Wait for at least one Dynatrace OneAgent pod to be created
     kubernetes.core.k8s_info:
       kind: Pod
@@ -94,7 +109,6 @@
     until: dt_oneagent_pods_creation.resources | length > 0
     retries: 20
     delay: 20
-
   - name: Wait for at least one Dynatrace ActiveGate pod to be created
     kubernetes.core.k8s_info:
       kind: Pod
@@ -105,7 +119,6 @@
     until: dt_activegate_pods_creation.resources | length > 0
     retries: 20
     delay: 20
-
   - name: Ensure all Dynatrace OneAgent pods are in Running state and ready
     kubernetes.core.k8s_info:
       kind: Pod
@@ -117,7 +130,6 @@
       dt_oneagent_pods.resources | selectattr('status.phase', 'equalto', 'Running') | map(attribute='status.containerStatuses') | selectattr('0.ready', 'equalto', true) | length == dt_oneagent_pods.resources | length
     retries: 20
     delay: 20
-
   - name: Ensure all Dynatrace ActiveGate pods are in Running state and ready
     kubernetes.core.k8s_info:
       kind: Pod
@@ -129,3 +141,12 @@
       dt_activegate_pods.resources | selectattr('status.phase', 'equalto', 'Running') | map(attribute='status.containerStatuses') | selectattr('0.ready', 'equalto', true) | length == dt_activegate_pods.resources | length
     retries: 20
     delay: 20
+  when: operator_mode == "classicFullStack"
+
+- include_role:
+    name: fluentbit
+  when: log_monitoring == "fluentbit"
+
+- include_role:
+    name: edge-connect
+  when: edge_connect == true

--- a/user-skel/ansible_collections/ace_box/ace_box/roles/dt-operator/templates/applicationMonitoring.yaml.j2
+++ b/user-skel/ansible_collections/ace_box/ace_box/roles/dt-operator/templates/applicationMonitoring.yaml.j2
@@ -1,4 +1,3 @@
-# The template for this file is available on GitHub: https://github.com/Dynatrace/dynatrace-operator/blob/v0.10.4/assets/samples/classicFullStack.yaml
 apiVersion: v1
 data:
   apiToken: "{{ vars[dt_operator_dt_access_token_name] | b64encode }}"
@@ -9,18 +8,17 @@ metadata:
   namespace: dynatrace
 type: Opaque
 ---
-apiVersion: dynatrace.com/v1beta1
+apiVersion: dynatrace.com/v1beta2
 kind: DynaKube
 metadata:
   name: dynakube
   namespace: dynatrace
-  # Automatically connect the kubernetes api to the dynatrace tenant endpoint to enable kubernetes monitoring.
   annotations:
-    feature.dynatrace.com/automatic-kubernetes-api-monitoring: "true"
+    feature.dynatrace.com/k8s-app-enabled: "true"
     feature.dynatrace.com/automatic-kubernetes-api-monitoring-cluster-name: "{{cluster_name}}"
 spec:
-  # Dynatrace apiUrl including the `/api` path at the end.
-  # For SaaS, set `ENVIRONMENTID` to your environment ID.
+  # Dynatrace apiUrl including the '/api' path at the end.
+  # For SaaS, set 'ENVIRONMENTID' to your environment ID.
   # For Managed, change the apiUrl address.
   # For instructions on how to determine the environment ID and how to configure the apiUrl address, see https://www.dynatrace.com/support/help/reference/dynatrace-concepts/environment-id/.
   apiUrl: "{{ dynatrace_tenant_url }}/api"
@@ -56,6 +54,7 @@ spec:
   # Make sure networkZones are enabled on your cluster before (see https://www.dynatrace.com/support/help/setup-and-configuration/network-zones/network-zones-basic-info/)
   #
   # networkZone: name-of-my-network-zone
+  
 
   # Optional: If enabled, and if Istio is installed on the Kubernetes environment, the
   # Operator will create the corresponding VirtualService and ServiceEntry objects to allow access
@@ -63,37 +62,65 @@ spec:
   #
   # enableIstio: false
 
-  # The namespaces which should be injected into
-  # If unset, all namespace will be injected into
-  # namespaceSelector has no effect on hostMonitoring or classicFullstack
-  # For examples regarding namespaceSelectors, see https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#resources-that-support-set-based-requirements
+  # Optional: Configuration for thresholding Dynatrace API requests in minutes. Default is 15 minutes.
   #
-  # namespaceSelector:
-  #   matchLabels:
-  #     app: my-app
-  #   matchExpressions:
-  #    - key: app
-  #      operator: In
-  #      values: [my-frontend, my-backend, my-database]
+  # dynatraceApiRequestThreshold: 15
+
+  # Configuration for Metadata Enrichment.
+  #
+  metadataEnrichment:
+    # Optional: Enables or disables metadata enrichment
+    # Defaults to "true"
+    #
+    enabled: true
+
+    # The namespaces in which metadata enrichment should be injected into
+    # If unset, all namespace will be injected into
+    # For examples regarding namespaceSelectors, see https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#resources-that-support-set-based-requirements
+    #
+    namespaceSelector:
+      matchExpressions:
+      - key: monitor
+        operator: NotIn
+        values:
+        - exclude
 
   # Configuration for OneAgent instances
   #
   oneAgent:
+    # Optional: Sets a host group for OneAgent.
+    #
+    # hostGroup: ""
+
     # Enables application-only monitoring and changes its settings
     # Cannot be used in conjunction with cloud-native fullstack monitoring, classic fullstack monitoring or host monitoring
     #
     applicationMonitoring:
+      # The namespaces which should be injected into
+      # If unset, all namespace will be injected into
+      # namespaceSelector has no effect on hostMonitoring or classicFullstack
+      # For examples regarding namespaceSelectors, see https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#resources-that-support-set-based-requirements
+      #
+      namespaceSelector:
+        matchExpressions:
+        - key: monitor
+          operator: NotIn
+          values:
+          - exclude
+      
+
       # Optional: If specified, indicates the OneAgent version to use
       # Defaults to the configured version on your Dynatrace environment
+      # Available versions can be found using the UI or the Dynatrace API
       # The version is expected to be provided in the semver format
-      # Example: {major.minor.release}, e.g., "1.200.0"
+      # Example: <major>.<minor>.<release>.<timestamp>, e.g. 1.200.0.20240501-085142
       #
-      # version:
+      # version: ""
 
       # Optional: If you want to use CSIDriver; disable if your cluster does not have 'nodes' to fall back to the volume approach.
       # Defaults to false
       #
-      useCSIDriver: false
+      useCSIDriver: true
 
       # Optional: The URI of the image that contains the codemodules specific OneAgent that will be injected into pods and applications.
       # For an example of a Dockerfile creating such an image, see https://dt-url.net/operator-docker-samples
@@ -122,15 +149,14 @@ spec:
     # - dynatrace-api
     #
     capabilities:
-      - routing
       - kubernetes-monitoring
-      - dynatrace-api
+      - routing
 
     # Optional: Sets the image used to deploy ActiveGate instances
     # Defaults to the latest ActiveGate image on the tenant's registry
     # Example: "ENVIRONMENTID.live.dynatrace.com/linux/activegate:latest"
     #
-    image: ""
+    # image: ""
 
     # Optional: Sets how many ActiveGate pods are spawned by the StatefulSet
     # Defaults to "1"


### PR DESCRIPTION
- Dynatrace monitoring enhancement with new dt-operator (recommended) mode
- default fluentbit collector for logs 
- optional edge-connect deployment
- improved documentation, clear instructions