### PR TITLE
remove edge_connect dependencies from dt-operator

### DIFF
--- a/user-skel/ansible_collections/ace_box/ace_box/roles/dt-operator/Readme.md
+++ b/user-skel/ansible_collections/ace_box/ace_box/roles/dt-operator/Readme.md
@@ -48,17 +48,15 @@ The Operator gets deployed in application only mode approach, check the `roles/d
 operator_mode: "applicationMonitoring"  # default & prefered deployment option
 dt_operator_release: "1.3.0-rc.0"       # operator release should be linked with the right operator mode
 log_monitoring: "fluentbit"
-edge_connect: false
 ```
 
-> Note: log monitoring is enabled by default, using the fluentbit collector and edge connect is disabled by default, but can be switched to 
+> Note: log monitoring is enabled by default, using the fluentbit collector. You can change the value of `log_monitoring` to `none`, in order to skip the deployent of the fluentbit collector.
+
 To deploy the Operator in application only mode (and default approach), variables can be set as follow:
 
 ```yaml
 - include_role:
     name: dt-operator
-  vars:
-    edge_connect: true
 ```
 
 If you decide to use the classicFullStack approach, you need to specify the variables as follow:
@@ -69,7 +67,10 @@ If you decide to use the classicFullStack approach, you need to specify the vari
   vars:
     operator_mode: "classicFullStack"  
     dt_operator_release: "1.2.2"
+    log_monitoring: "oneagent"
 ```
+
+> Note: by switching the `log_monitoring` variable to oneagent, it will skip the fluentbit collector deployment, as the logs are getting collected by the OneAgent itself.
 
 ## Extra variables
 

--- a/user-skel/ansible_collections/ace_box/ace_box/roles/dt-operator/defaults/main.yml
+++ b/user-skel/ansible_collections/ace_box/ace_box/roles/dt-operator/defaults/main.yml
@@ -16,7 +16,6 @@
 operator_mode: "applicationMonitoring"  # default & prefered deployment option
 dt_operator_release: "1.3.0-rc.0"       # operator release should be linked with the right operator mode
 log_monitoring: "fluentbit"
-edge_connect: false
 
 # operator_mode: "classicFullStack"  
 # dt_operator_release: "1.2.2"

--- a/user-skel/ansible_collections/ace_box/ace_box/roles/dt-operator/tasks/main.yml
+++ b/user-skel/ansible_collections/ace_box/ace_box/roles/dt-operator/tasks/main.yml
@@ -146,7 +146,3 @@
 - include_role:
     name: fluentbit
   when: log_monitoring == "fluentbit"
-
-- include_role:
-    name: edge-connect
-  when: edge_connect == true


### PR DESCRIPTION
Notes:
- removes edge_connect dependencies from dt-operator
- more details on how to configure log_monitoring fluentbit variable