### PR TITLE
update dt_operator_release to v1.4.0

### DIFF
--- a/user-skel/ansible_collections/ace_box/ace_box/roles/dt-operator/defaults/main.yml
+++ b/user-skel/ansible_collections/ace_box/ace_box/roles/dt-operator/defaults/main.yml
@@ -14,7 +14,7 @@
 
 ---
 operator_mode: "applicationMonitoring"  # default & prefered deployment option
-dt_operator_release: "1.3.0-rc.0"       # operator release should be linked with the right operator mode
+dt_operator_release: "1.4.0"       # operator release should be linked with the right operator mode
 log_monitoring: "off"
 
 # operator_mode: "classicFullStack"  


### PR DESCRIPTION
dt_operator_release was using a release candidate version. Updated to a prod version v1.4.0