### PR TITLE
typo fix deploying dt-edge-connect credentials

### DIFF
--- a/user-skel/ansible_collections/ace_box/ace_box/roles/dt-edge-connect/tasks/main.yaml
+++ b/user-skel/ansible_collections/ace_box/ace_box/roles/dt-edge-connect/tasks/main.yaml
@@ -52,5 +52,5 @@
 
 - name: Generate credentials
   include_role:
-    name: edge-connect
+    name: dt-edge-connect
     tasks_from: generate-credentials


### PR DESCRIPTION
edge-connect deployment was failing because of a typo in one of the subtasks

Fixed by calling the right role name:
```
- name: Generate credentials
  include_role:
    name: dt-edge-connect
    tasks_from: generate-credentials
```