### PR TITLE
dt-plaform app validation feature

### DIFF
--- a/user-skel/ansible_collections/ace_box/ace_box/roles/dt-platform/README.md
+++ b/user-skel/ansible_collections/ace_box/ace_box/roles/dt-platform/README.md
@@ -36,6 +36,12 @@ Requires vars:
 Sets facts:
 - dt_app_id
 
+Optional vars:
+
+|Variable name|Description|
+|---|---|
+|app_validation|true/false, false by default. Switch to true if you want to validate if the app already exist in the tenant|
+
 ## validate-app-version
 
 Sets `dt_app_version` if a specific Dynatarce app is installed. `dt_app_version` is undefined if app isn't found. This task can be used to validate installation status of a required app and e.g. fail deployment early.

--- a/user-skel/ansible_collections/ace_box/ace_box/roles/dt-platform/defaults/main.yml
+++ b/user-skel/ansible_collections/ace_box/ace_box/roles/dt-platform/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+app_validation: false

--- a/user-skel/ansible_collections/ace_box/ace_box/roles/dt-platform/defaults/main.yml
+++ b/user-skel/ansible_collections/ace_box/ace_box/roles/dt-platform/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-app_validation: false
+app_validation: true

--- a/user-skel/ansible_collections/ace_box/ace_box/roles/dt-platform/tasks/install-app-artifact.yml
+++ b/user-skel/ansible_collections/ace_box/ace_box/roles/dt-platform/tasks/install-app-artifact.yml
@@ -37,22 +37,23 @@
     - set_fact:
         dt_oauth_access_token: "{{ auth_response_raw.json.access_token }}"
 
-# - include_role:
-#     name: dt-platform
-#     tasks_from: validate-app-version
-#   vars:
-#     dt_environment_url_gen3: "{{ extra_vars.dt_environment_url_gen3 }}"
-#     dt_oauth_sso_endpoint: "{{ extra_vars.dt_oauth_sso_endpoint }}"
-#     dt_oauth_client_id: "{{ extra_vars.dt_oauth_client_id }}"
-#     dt_oauth_client_secret: "{{ extra_vars.dt_oauth_client_secret }}"
-#     dt_oauth_account_urn: "{{ extra_vars.dt_oauth_account_urn }}"
-
-# - block:
-#     - debug:
-#         msg: "{{ dt_app_version }} of {{ dt_app_id }} is installed in target environment already. Skipping installation."
-#     - set_fact:
-#         dt_app_id: "{{ dt_app_id }}"
-#   when: dt_app_version is defined and dt_app_version is not none
+- block:
+  - include_role:
+      name: dt-platform
+      tasks_from: validate-app-version
+    vars:
+      dt_environment_url_gen3: "{{ extra_vars.dt_environment_url_gen3 }}"
+      dt_oauth_sso_endpoint: "{{ extra_vars.dt_oauth_sso_endpoint }}"
+      dt_oauth_client_id: "{{ extra_vars.dt_oauth_client_id }}"
+      dt_oauth_client_secret: "{{ extra_vars.dt_oauth_client_secret }}"
+      dt_oauth_account_urn: "{{ extra_vars.dt_oauth_account_urn }}"
+  - block:
+      - debug:
+          msg: "{{ dt_app_version }} of {{ dt_app_id }} is installed in target environment already. Skipping installation."
+      - set_fact:
+          dt_app_id: "{{ dt_app_id }}"
+    when: dt_app_version is defined and dt_app_version is not none
+  when: app_validation == true
 
 - block:
     - name: "Install app {{ dt_app_id }}"

--- a/user-skel/ansible_collections/ace_box/ace_box/roles/dt-platform/tasks/validate-app-version.yml
+++ b/user-skel/ansible_collections/ace_box/ace_box/roles/dt-platform/tasks/validate-app-version.yml
@@ -46,13 +46,9 @@
       Content-Type: "application/json"
       Authorization: "Bearer {{ dt_oauth_access_token }}"
   register: get_app_response_raw
-# - set_fact:
-#     dt_app_version: null
-#   when: get_app_response_raw.status == 404
-
-# - set_fact:
-#     dt_app_version: "{{ get_app_response_raw.json.version }}"
-#   when: get_app_response_raw.status == 200
+  until:  get_app_response_raw.json.id == dt_app_id
+  retries: 12          # check 12 times
+  delay: 300           # with 5min delay (total 60min)
 
 - set_fact:
     dt_app_version: "{{ get_app_response_raw.json.version | default(omit) }}"


### PR DESCRIPTION
The following PR adds the following functionalities
- setting validation in false by default
- uncommenting validation, making it available again
- setting 1 hour retry logic waiting for the app to be available