### PR TITLE
param dynakube apiVersion

### DIFF
--- a/user-skel/ansible_collections/ace_box/ace_box/roles/dt-operator/defaults/main.yml
+++ b/user-skel/ansible_collections/ace_box/ace_box/roles/dt-operator/defaults/main.yml
@@ -14,7 +14,8 @@
 
 ---
 operator_mode: "applicationMonitoring"  # default & prefered deployment option
-dt_operator_release: "1.4.0"            # format without v for helm
+dt_operator_release: "1.7.0"            # format without v for helm
+dynakube_api_version: "dynatrace.com/v1beta5"
 log_monitoring: "off"
 
 # operator_mode: "classicFullStack"  

--- a/user-skel/ansible_collections/ace_box/ace_box/roles/dt-operator/templates/applicationMonitoring.yaml.j2
+++ b/user-skel/ansible_collections/ace_box/ace_box/roles/dt-operator/templates/applicationMonitoring.yaml.j2
@@ -8,7 +8,7 @@ metadata:
   namespace: dynatrace
 type: Opaque
 ---
-apiVersion: dynatrace.com/v1beta2
+apiVersion: {{ dynakube_api_version }}
 kind: DynaKube
 metadata:
   name: dynakube

--- a/user-skel/ansible_collections/ace_box/ace_box/roles/dt-operator/templates/classicFullStack.yaml.j2
+++ b/user-skel/ansible_collections/ace_box/ace_box/roles/dt-operator/templates/classicFullStack.yaml.j2
@@ -9,7 +9,7 @@ metadata:
   namespace: dynatrace
 type: Opaque
 ---
-apiVersion: dynatrace.com/v1beta1
+apiVersion: {{ dynakube_api_version }}
 kind: DynaKube
 metadata:
   name: dynakube

--- a/user-skel/ansible_collections/ace_box/ace_box/roles/dt-operator/templates/cloudNativeFullStack.yaml.j2
+++ b/user-skel/ansible_collections/ace_box/ace_box/roles/dt-operator/templates/cloudNativeFullStack.yaml.j2
@@ -9,7 +9,7 @@ metadata:
   namespace: dynatrace
 type: Opaque
 ---
-apiVersion: dynatrace.com/v1beta1
+apiVersion: {{ dynakube_api_version }}
 kind: DynaKube
 metadata:
   name: dynakube


### PR DESCRIPTION
Update default operator to 1.7 and add apiVersion as new var.

Avoid use of deprecated dynakube apiVersions.

https://github.com/Dynatrace/dynatrace-operator/tree/main/assets/samples/dynakube