### PR TITLE
when clause includes classic & cloudNative, not appOnly

### DIFF
--- a/user-skel/ansible_collections/ace_box/ace_box/roles/dt-operator/tasks/main.yml
+++ b/user-skel/ansible_collections/ace_box/ace_box/roles/dt-operator/tasks/main.yml
@@ -141,7 +141,7 @@
       dt_activegate_pods.resources | selectattr('status.phase', 'equalto', 'Running') | map(attribute='status.containerStatuses') | selectattr('0.ready', 'equalto', true) | length == dt_activegate_pods.resources | length
     retries: 20
     delay: 20
-  when: operator_mode == "classicFullStack"
+  when: operator_mode != "applicationMonitoring"
 
 - include_role:
     name: fluentbit


### PR DESCRIPTION
Currently, the wait for pods ready task exists only for the classic Dynatrace Operator workflow (operator_mode == "classic"). This logic is not strictly required for applicationMonitoring mode, but it is relevant for cloudNativeFullStack deployments to ensure all injected pods are ready before proceeding.

https://github.com/Dynatrace/ace-box/blob/dev/user-skel/ansible_collections/ace_box/ace_box/roles/dt-operator/tasks/main.yml#L144

This allows the waiting logic to run for both classic and cloudNative modes, while skipping it for pure application monitoring scenarios.

Why this matters:

CloudNative mode involves OneAgent injection and ActiveGate routing, which require pods to be fully ready before subsequent steps.
Improves reliability of automation workflows in ACE Box for Kubernetes environments using Dynatrace Operator
Proposed change, update the condition to:
when: operator_mode != "applicationMonitoring"