### PR TITLE
Update pip install command for kubernetes package

### DIFF
--- a/user-skel/ansible_collections/ace_box/ace_box/roles/k3s/tasks/main.yml
+++ b/user-skel/ansible_collections/ace_box/ace_box/roles/k3s/tasks/main.yml
@@ -54,7 +54,7 @@
   become: true
   become_user: root
   shell:
-    cmd: python3 -m pip install --break-system-packages kubernetes
+    cmd: python3 -m pip install kubernetes --ignore-installed PyYAML
 
 - name: Create a directory if it does not exist
   become: true


### PR DESCRIPTION
Installation breaks in AWS with the current setup, changed the command to ignore installed PyYAML, otherwise it would try to uninstall or update it, which fails as (`Cannot uninstall PyYAML 5.3.1\n╰─> It is a distutils installed project and thus we cannot accurately determine which files belong to it which would lead to only a partial uninstall`)

I have only tested this on AWS, as I don't have a GCP or Azure environment to test it. 