### PR TITLE
Change root block device volume type to gp3

### DIFF
--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -111,6 +111,7 @@ resource "aws_instance" "acebox" {
   key_name      = aws_key_pair.generated_key.key_name
 
   root_block_device {
+    volume_type = "gp3"
     volume_size = var.disk_size
   }
 


### PR DESCRIPTION
By default a gp2 volume is created for the disk, but this is restricted on for most AWS users at Dynatrace and since gp3 is cheaper and has better performance, it makes sense switch to gp3