### PR TITLE
added break-system packages for gcp compatilibity

### DIFF
--- a/user-skel/ansible_collections/ace_box/ace_box/roles/k3s/tasks/main.yml
+++ b/user-skel/ansible_collections/ace_box/ace_box/roles/k3s/tasks/main.yml
@@ -54,7 +54,7 @@
   become: true
   become_user: root
   shell:
-    cmd: python3 -m pip install kubernetes --ignore-installed PyYAML
+    cmd: python3 -m pip install kubernetes --ignore-installed PyYAML --break-system-packages
 
 - name: Create a directory if it does not exist
   become: true


### PR DESCRIPTION
needed for Python 3.12+ which enforces PEP 668 to prevent conflicts with system-managed Python packages.