### PR TITLE
Add 'list' verb to edgeconnect-role.yaml

### DIFF
--- a/user-skel/ansible_collections/ace_box/ace_box/roles/dt-edge-connect/templates/edgeconnect-role.yaml
+++ b/user-skel/ansible_collections/ace_box/ace_box/roles/dt-edge-connect/templates/edgeconnect-role.yaml
@@ -6,4 +6,4 @@ metadata:
 rules:
   - apiGroups: ["apps"]
     resources: ["deployments"]
-    verbs: ["get", "patch"]
+    verbs: ["get", "patch", "list"]


### PR DESCRIPTION
Add 'list' verb to edgeconnect-role.yaml
refer to upstream docs: https://docs.dynatrace.com/docs/ingest-from/setup-on-k8s/guides/deployment-and-configuration/edgeconnect/kubernetes-automation#define-roleclusterrole