### PR TITLE
fix(docker): add retry logic to Docker restart handler

### DIFF
--- a/user-skel/ansible_collections/ace_box/ace_box/roles/docker/handlers/main.yml
+++ b/user-skel/ansible_collections/ace_box/ace_box/roles/docker/handlers/main.yml
@@ -16,6 +16,10 @@
 - name: Restart Docker
   become: true
   become_user: root
-  service:
+  ansible.builtin.systemd:
     name: docker
     state: restarted
+  register: docker_restart_result
+  retries: 3
+  delay: 5
+  until:  docker_restart_result is succeeded


### PR DESCRIPTION
## Problem:
Docker restart handler occasionally fails with the error:

```
Unable to restart service docker:  Job for docker.service failed because the control process exited with error code."
```

Example logs showing transient nftables cleanup errors:

```
Dec 29 14:47:21 dockerd[22203]: time="2025-12-29T14:47:21.444766639Z" level=info msg="Deleting nftables IPv4 rules" error="exit status 1"
Dec 29 14:47:21 dockerd[22203]:  time="2025-12-29T14:47:21.459806472Z" level=info msg="Deleting nftables IPv6 rules" error="exit status 1"
```
These errors are non-fatal and Docker typically succeeds on retry, but without retry logic in Ansible, the handler fails the playbook even though Docker would recover automatically.

## Solution
Add retry logic to the Docker restart handler:

Retries: 3 attempts
Delay: 5 seconds between attempts
Condition: Retry until the restart succeeds

