### PR TITLE
Increase delay for Docker restart to 30 seconds

### DIFF
--- a/user-skel/ansible_collections/ace_box/ace_box/roles/docker/handlers/main.yml
+++ b/user-skel/ansible_collections/ace_box/ace_box/roles/docker/handlers/main.yml
@@ -21,5 +21,5 @@
     state: restarted
   register: docker_restart_result
   retries: 3
-  delay: 5
+  delay: 30  # Increased to 15 seconds to avoid systemd rate limiting
   until:  docker_restart_result is succeeded

--- a/user-skel/ansible_collections/ace_box/ace_box/roles/docker/handlers/main.yml
+++ b/user-skel/ansible_collections/ace_box/ace_box/roles/docker/handlers/main.yml
@@ -21,5 +21,5 @@
     state: restarted
   register: docker_restart_result
   retries: 3
-  delay: 30  # Increased to 15 seconds to avoid systemd rate limiting
+  delay: 30  # Increased to 30 seconds to avoid systemd rate limiting
   until:  docker_restart_result is succeeded


### PR DESCRIPTION
Increased the delay for Docker restart to avoid systemd rate limiting.